### PR TITLE
Choose correct emoji picker when limited emoji set

### DIFF
--- a/assets/javascripts/discourse/components/retort-picker.js.es6
+++ b/assets/javascripts/discourse/components/retort-picker.js.es6
@@ -15,7 +15,7 @@ export default EmojiPicker.extend({
 
   _loadCategoriesEmojis() {
     if (siteSettings.retort_limited_emoji_set) {
-      const $picker = $('.emoji-picker')
+      const $picker = $('.retort-picker.emoji-picker')
       $picker.html("")
       siteSettings.retort_allowed_emojis.split('|').map((code) => {
         $picker.append(`<button type="button" title="${code}" class="emoji" />`)


### PR DESCRIPTION
If `retort_limited_emoji_set` is `true`, both the retort emoji picker (`.retort-picker.emoji-picker`) and the standard emoji picker (`.emoji-picker`) got processed, with the standard emoji picker being used.  This PR should fix it.