### PR TITLE
Fixed emoji picker

### DIFF
--- a/assets/javascripts/discourse/components/retort-picker.js.es6
+++ b/assets/javascripts/discourse/components/retort-picker.js.es6
@@ -4,6 +4,10 @@ import { emojiUrlFor } from 'discourse/lib/text'
 const siteSettings = Discourse.SiteSettings
 
 export default EmojiPicker.extend({
+  show() {
+    this.didInsertElement();
+    this._super();
+  },
 
   _scrollTo() {
     if (siteSettings.retort_limited_emoji_set) {

--- a/assets/javascripts/discourse/components/retort-picker.js.es6
+++ b/assets/javascripts/discourse/components/retort-picker.js.es6
@@ -9,6 +9,11 @@ export default EmojiPicker.extend({
     this._super();
   },
 
+  close() {
+    this._super();
+    this.willDestroyElement();
+  },
+  
   _scrollTo() {
     if (siteSettings.retort_limited_emoji_set) {
       return

--- a/assets/javascripts/discourse/components/retort-picker.js.es6
+++ b/assets/javascripts/discourse/components/retort-picker.js.es6
@@ -24,11 +24,11 @@ export default EmojiPicker.extend({
 
   _loadCategoriesEmojis() {
     if (siteSettings.retort_limited_emoji_set) {
-      const $picker = $('.emoji-picker')
+      const $picker = this.$('.emoji-picker')
       $picker.html("")
       siteSettings.retort_allowed_emojis.split('|').map((code) => {
         $picker.append(`<button type="button" title="${code}" class="emoji" />`)
-        $(`button.emoji[title="${code}"]`).css("background-image", `url("${emojiUrlFor(code)}")`)
+        this.$(`button.emoji[title="${code}"]`).css("background-image", `url("${emojiUrlFor(code)}")`)
       })
       this._bindEmojiClick($picker);
     } else {


### PR DESCRIPTION
These changes will make retort work with the emoji-picker from the reply window.

Due to the `$picker` global variable in Discourse's `EmojiPicker`, when the retort-picker is shown we must make sure that `$picker` is set to the right object.  And there is only one method call to do that.

So the trick is to call `didInsertElement` before `show` and call `didDeleteElement` after `close`.

With this change, retort-picker will work well with the reply window.

It will not, however, work with `discourse/babble` yet, as I suppose `discourse/babble` also uses the same flawed method to put up an emoji-picker.
