### PR TITLE
Fixed retort to work with latest Discourse.

### DIFF
--- a/assets/javascripts/discourse/components/retort-picker.js.es6
+++ b/assets/javascripts/discourse/components/retort-picker.js.es6
@@ -4,16 +4,6 @@ import { emojiUrlFor } from 'discourse/lib/text'
 const siteSettings = Discourse.SiteSettings
 
 export default EmojiPicker.extend({
-  show() {
-    this.didInsertElement();
-    this._super();
-  },
-
-  close() {
-    this._super();
-    this.willDestroyElement();
-  },
-  
   _scrollTo() {
     if (siteSettings.retort_limited_emoji_set) {
       return

--- a/assets/javascripts/discourse/components/retort-picker.js.es6
+++ b/assets/javascripts/discourse/components/retort-picker.js.es6
@@ -4,6 +4,10 @@ import { emojiUrlFor } from 'discourse/lib/text'
 const siteSettings = Discourse.SiteSettings
 
 export default EmojiPicker.extend({
+  show() {
+    this.didInsertElement();
+    this._super();
+  },
 
   _scrollTo() {
     if (siteSettings.retort_limited_emoji_set) {

--- a/assets/javascripts/discourse/components/retort-picker.js.es6
+++ b/assets/javascripts/discourse/components/retort-picker.js.es6
@@ -9,6 +9,11 @@ export default EmojiPicker.extend({
     this._super();
   },
 
+  close() {
+    this._super();
+    this.willDestroyElement();
+  },
+  
   _scrollTo() {
     if (siteSettings.retort_limited_emoji_set) {
       return

--- a/assets/javascripts/discourse/components/retort-picker.js.es6
+++ b/assets/javascripts/discourse/components/retort-picker.js.es6
@@ -24,11 +24,11 @@ export default EmojiPicker.extend({
 
   _loadCategoriesEmojis() {
     if (siteSettings.retort_limited_emoji_set) {
-      const $picker = $('.emoji-picker')
+      const $picker = this.$('.emoji-picker')
       $picker.html("")
       siteSettings.retort_allowed_emojis.split('|').map((code) => {
         $picker.append(`<button type="button" title="${code}" class="emoji" />`)
-        $(`button.emoji[title="${code}"]`).css("background-image", `url("${emojiUrlFor(code)}")`)
+        this.$(`button.emoji[title="${code}"]`).css("background-image", `url("${emojiUrlFor(code)}")`)
       })
       this._bindEmojiClick($picker);
     } else {

--- a/plugin.rb
+++ b/plugin.rb
@@ -27,7 +27,7 @@ after_initialize do
   end
 
   class ::Retort::RetortsController < ApplicationController
-    before_filter :verify_post_and_user, only: :update
+    before_action :verify_post_and_user, only: :update
 
     def update
       retort.toggle_user(current_user)


### PR DESCRIPTION
Discourse's emoji picker got changed a while ago which broke this plugin. Those issues have now been fixed in the new Discourse versions.

This PR fixes a few prob with finding the correct emoji picker when the reply window is open.

EDIT: I've pushed through another commit that changes `before_filter` to `before_action` required for Rails 5.
