### PR TITLE
Text emojis

### DIFF
--- a/assets/javascripts/discourse/components/retort-picker.js.es6
+++ b/assets/javascripts/discourse/components/retort-picker.js.es6
@@ -1,5 +1,6 @@
 import EmojiPicker from 'discourse/components/emoji-picker'
 import { emojiUrlFor } from 'discourse/lib/text'
+import { allowedEmojis, allowedTextEmojis } from '../lib/retort';
 
 const siteSettings = Discourse.SiteSettings
 
@@ -39,14 +40,14 @@ export default EmojiPicker.extend({
       const basis   = this._flexBasis()
       $picker.html("")
 
-      const emojis = this._allowedEmojis();
+      const emojis = allowedEmojis();
       emojis.map((code) => {
         $picker.append(`<button type="button" title="${code}" class="emoji" />`)
         this.$(`button.emoji[title="${code}"]`).css("background-image", `url("${emojiUrlFor(code)}")`)
                                                .css("flex-basis", `${basis}%`)
       })
 
-      const textEmojis = this._allowedTextEmojis();
+      const textEmojis = allowedTextEmojis();
       if (textEmojis.length) {
         if (emojis.length) {
           $picker.append("<hr>");
@@ -65,23 +66,8 @@ export default EmojiPicker.extend({
     }
   },
 
-  _allAllowedEmojis() {
-    return siteSettings.retort_allowed_emojis.split('|');
-  },
-
-  _allowedEmojis() {
-    return this._allAllowedEmojis()
-      .filter(e => e.indexOf(":text") === -1);
-  },
-
-  _allowedTextEmojis() {
-    return this._allAllowedEmojis()
-      .filter(e => e.indexOf(":text") > -1)
-      .map(e => e.split(":")[0]);
-  },
-
   _flexBasis() {
-    return (100 / this._emojisPerRow[this._allowedEmojis().length] || 5)
+    return (100 / this._emojisPerRow[allowedEmojis().length] || 5)
   },
 
   _emojisPerRow: {

--- a/assets/javascripts/discourse/components/retort-picker.js.es6
+++ b/assets/javascripts/discourse/components/retort-picker.js.es6
@@ -38,19 +38,46 @@ export default EmojiPicker.extend({
       const $picker = this.$('.emoji-picker')
       const basis   = this._flexBasis()
       $picker.html("")
-      this._allowedEmojis().map((code) => {
+
+      const emojis = this._allowedEmojis();
+      emojis.map((code) => {
         $picker.append(`<button type="button" title="${code}" class="emoji" />`)
         this.$(`button.emoji[title="${code}"]`).css("background-image", `url("${emojiUrlFor(code)}")`)
                                                .css("flex-basis", `${basis}%`)
       })
+
+      const textEmojis = this._allowedTextEmojis();
+      if (textEmojis.length) {
+        if (emojis.length) {
+          $picker.append("<hr>");
+        }
+        $picker.append("<div class='text-emoji-wrapper'>");
+        textEmojis.forEach((code) => {
+          $picker.append(`<button type="button" title="${code}" class="emoji text" />`);
+          this.$(`button.emoji[title="${code}"]`).css("background-image", `url("${emojiUrlFor(code)}")`);
+        });
+        $picker.append("</div>");
+      }
+
       this._bindEmojiClick($picker);
     } else {
       this._super()
     }
   },
 
+  _allAllowedEmojis() {
+    return siteSettings.retort_allowed_emojis.split('|');
+  },
+
   _allowedEmojis() {
-    return siteSettings.retort_allowed_emojis.split('|')
+    return this._allAllowedEmojis()
+      .filter(e => e.indexOf(":text") === -1);
+  },
+
+  _allowedTextEmojis() {
+    return this._allAllowedEmojis()
+      .filter(e => e.indexOf(":text") > -1)
+      .map(e => e.split(":")[0]);
   },
 
   _flexBasis() {

--- a/assets/javascripts/discourse/initializers/retort-init.js.es6
+++ b/assets/javascripts/discourse/initializers/retort-init.js.es6
@@ -1,8 +1,9 @@
 import { withPluginApi } from 'discourse/lib/plugin-api'
 import TopicRoute from 'discourse/routes/topic'
-import Retort from '../lib/retort'
+import { default as Retort, applyTextEmojiClass } from '../lib/retort'
 import { registerEmoji } from 'pretty-text/emoji'
 import { emojiUrlFor } from 'discourse/lib/text'
+import { on } from 'ember-addons/ember-computed-decorators';
 
 function initializePlugin(api) {
 
@@ -45,7 +46,20 @@ function initializePlugin(api) {
 
   api.attachWidgetAction('post-menu', 'clickRetort', function() {
     Retort.openPicker(this.findAncestorModel())
-  })
+  });
+
+  api.modifyClass('component:emoji-picker', {
+    @on("didUpdateAttrs")
+    hideTextEmojis() {
+      if (this.get("active")) {
+        applyTextEmojiClass();
+      }
+    }
+  });
+
+  api.decorateCooked($elem => {
+    applyTextEmojiClass();
+  });
 }
 
 export default {

--- a/assets/javascripts/discourse/lib/retort.js.es6
+++ b/assets/javascripts/discourse/lib/retort.js.es6
@@ -47,3 +47,32 @@ export default Ember.Object.create({
     this.set('picker.limitOptions', Discourse.SiteSettings.retort_limited_emoji_set)
   }
 })
+
+function allAllowedEmojis() {
+  const setting = Discourse.SiteSettings.retort_allowed_emojis;
+  return setting.length ? setting.split('|') : [];
+}
+
+function allowedEmojis() {
+  return allAllowedEmojis()
+    .filter(code => code.indexOf(":text") === -1);
+}
+
+function allowedTextEmojis() {
+  return allAllowedEmojis()
+    .filter(code => code.indexOf(":text") > -1)
+    .map(code => code.split(":")[0]);
+}
+
+function applyTextEmojiClass() {
+  const textEmojis = allowedTextEmojis();
+  if (textEmojis.length) {
+    Ember.run.scheduleOnce('afterRender', () => {
+      textEmojis.forEach(code => {
+        $(`.emoji[title="${code}"], .emoji[title=":${code}:"]`).addClass('text');
+      });
+    });
+  }
+}
+
+export { allAllowedEmojis, allowedEmojis, allowedTextEmojis, applyTextEmojiClass };

--- a/assets/javascripts/discourse/widgets/retort-toggle.js.es6
+++ b/assets/javascripts/discourse/widgets/retort-toggle.js.es6
@@ -7,6 +7,29 @@ export default createWidget('retort-toggle', {
 
   buildKey: (attrs) => `retort-toggle-${attrs.emoji}-${attrs.usernames.length}`,
 
+  buildClasses(attrs) {
+    let classes = '';
+
+    const allowedEmojis = this._allowedEmojis();
+    if (allowedEmojis.length) {
+      const textEmojis = this._textEmojis();
+      if (textEmojis.length && textEmojis.indexOf(attrs.emoji) > -1) {
+        classes += ' text';
+      }
+    }
+
+    return classes;
+  },
+
+  _allowedEmojis() {
+    return Discourse.SiteSettings.retort_allowed_emojis.split('|');
+  },
+
+  _textEmojis() {
+    return this._allowedEmojis().filter(e => e.indexOf(':text') > -1)
+      .map(e => e.split(':')[0]);
+  },
+
   defaultState(attrs) {
     return {
       emoji:     attrs.emoji,

--- a/assets/javascripts/discourse/widgets/retort-toggle.js.es6
+++ b/assets/javascripts/discourse/widgets/retort-toggle.js.es6
@@ -1,6 +1,6 @@
 import { createWidget } from 'discourse/widgets/widget'
 import template from '../widgets/templates/retort-toggle'
-import Retort from '../lib/retort'
+import { default as Retort, allowedTextEmojis } from '../lib/retort'
 
 export default createWidget('retort-toggle', {
   tagName: 'button.post-retort',
@@ -10,24 +10,12 @@ export default createWidget('retort-toggle', {
   buildClasses(attrs) {
     let classes = '';
 
-    const allowedEmojis = this._allowedEmojis();
-    if (allowedEmojis.length) {
-      const textEmojis = this._textEmojis();
-      if (textEmojis.length && textEmojis.indexOf(attrs.emoji) > -1) {
-        classes += ' text';
-      }
+    const textEmojis = allowedTextEmojis();
+    if (textEmojis.length && textEmojis.indexOf(attrs.emoji) > -1) {
+      classes += ' text';
     }
 
     return classes;
-  },
-
-  _allowedEmojis() {
-    return Discourse.SiteSettings.retort_allowed_emojis.split('|');
-  },
-
-  _textEmojis() {
-    return this._allowedEmojis().filter(e => e.indexOf(':text') > -1)
-      .map(e => e.split(':')[0]);
   },
 
   defaultState(attrs) {

--- a/assets/stylesheets/retort.scss
+++ b/assets/stylesheets/retort.scss
@@ -53,6 +53,19 @@
     font-weight: bold;
     color: $secondary;
   }
+
+  &.text {
+    background: initial;
+
+    img {
+      width: 80px;
+      height: 20px;
+    }
+
+    .post-retort__count {
+      color: $primary;
+    }
+  }
 }
 
 .retort__emoji-picker-wrapper {
@@ -68,6 +81,16 @@
       background-size: 40px;
       margin: 0;
       padding: 10px 0;
+    }
+
+    .text-emoji-wrapper {
+      padding: 0 10px;
+    }
+
+    button.emoji.text {
+      background-size: initial;
+      padding: 10px;
+      width: 100px;
     }
   }
 
@@ -89,5 +112,9 @@
     }
 
     .emoji-picker { bottom: auto !important; }
+  }
+
+  hr {
+    width: 100%;
   }
 }

--- a/assets/stylesheets/retort.scss
+++ b/assets/stylesheets/retort.scss
@@ -88,9 +88,7 @@
     }
 
     button.emoji.text {
-      background-size: initial;
       padding: 10px;
-      width: 100px;
     }
   }
 
@@ -117,4 +115,9 @@
   hr {
     width: 100%;
   }
+}
+
+.emoji.text {
+  background-size: initial !important;
+  width: 100px !important;
 }

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2,7 +2,7 @@ en:
   site_settings:
     retort_enabled: "Enable Retort reactions plugin."
     retort_limited_emoji_set: "Constrain the list of reactions to the list specified below"
-    retort_allowed_emojis: "List out the emojis you'd like to allow, separated by the '|' character"
+    retort_allowed_emojis: "List out the emojis you'd like to allow, separated by the '|' character. Add ':text' after text emojis."
     retort_emojis_per_row: "Select how many custom emojis will appear per row (Leave blank to have them all appear in a single row)"
     retort_allow_multiple_reactions: "Allow users to react multiple times to the same post"
     retort_disabled_categories: "List out the categories you'd like to DISABLE retort for, separated by the '|' character"

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,6 +1,6 @@
 # name: retort
 # about: Reactions plugin for Discourse
-# version: 1.1.7
+# version: 1.2.0
 # authors: James Kiesel (gdpelican)
 # url: https://github.com/gdpelican/retort
 


### PR DESCRIPTION
@gdpelican This is a WIP for adding support for text emojis.

- Admins can add text emojis as custom emojis (display is 80x20, so ideal image size is 160x40)
- Admins can add text emojis to the list of allowed emojis using the qualifier ':text'
- Users can select text emojis as a retort from a delineated list of text emojis in the retort picker
- Users can select text emojis in the standard list of emojis when composing or editing a post (basically, I've attempted the route of supporting them as removing them entirely from the standard list is tricker)

Interested in your thoughts