### PR TITLE
Upgraded retort list

### DIFF
--- a/assets/javascripts/discourse/initializers/retort-init.js.es6
+++ b/assets/javascripts/discourse/initializers/retort-init.js.es6
@@ -111,7 +111,7 @@ function initializePlugin(api) {
           this.attach("small-user-list", {
             users: state.retortedUsers,
             addSelf: false,
-            listClassName: "who-liked",
+            listClassName: "who-retorted",
             description: "post.actions.people.retort",
             count: this.retortName(state.retort)
           })

--- a/assets/javascripts/discourse/initializers/retort-init.js.es6
+++ b/assets/javascripts/discourse/initializers/retort-init.js.es6
@@ -106,14 +106,18 @@ function initializePlugin(api) {
   });
 
   api.reopenWidget('post', {
+    toggledRetort(retort) {
+      if (this.state.showingRetortsFor == retort) {
+        this.clearWhoRetorted();
+      }
+    },
+
     toggleWhoRetorted(retort) {
       if (this.state.showingRetortsFor == retort) {
-        this.state.retortedUsers = [];
-        this.state.showingRetortsFor = null;
+        this.clearWhoRetorted();
       } else {
         this.getWhoRetorted(retort);
       }
-      this.scheduleRerender();
     },
 
     getWhoRetorted(retort) {

--- a/assets/javascripts/discourse/initializers/retort-init.js.es6
+++ b/assets/javascripts/discourse/initializers/retort-init.js.es6
@@ -25,7 +25,7 @@ function initializePlugin(api) {
     Retort.storeWidget(helper)
 
     return _.map(post.retorts, (retort) => {
-      { usernames, emoji } = retort;
+      let { usernames, emoji } = retort;
       let contents = [];
 
       if (siteSettings.retort_standard_count && usernames.length > 0) {

--- a/assets/javascripts/discourse/initializers/retort-init.js.es6
+++ b/assets/javascripts/discourse/initializers/retort-init.js.es6
@@ -69,17 +69,17 @@ function initializePlugin(api) {
       return this._super();
     },
 
-    getWhoRetorted(emoji) {
+    getWhoRetorted(retort) {
       const { attrs, state } = this;
 
       return ajax(`/retorts/${attrs.id}/users`, {
         data: {
-          retort: emoji
+          retort
         }
       }).then(users => {
         if (users && users.length) {
           state.retortedUsers = users.map(avatarAtts);
-          state.retort = emoji;
+          state.retort = retort;
           this.scheduleRerender();
         }
       });

--- a/assets/javascripts/discourse/initializers/retort-init.js.es6
+++ b/assets/javascripts/discourse/initializers/retort-init.js.es6
@@ -22,7 +22,7 @@ function initializePlugin(api) {
 
     if (Retort.disabledFor(postId)) { return }
 
-    Retort.storeWidget(helper);
+    Retort.storeWidget(helper)
 
     return _.map(post.retorts, (retort) => {
       let usernames = retort.usernames;

--- a/assets/javascripts/discourse/initializers/retort-init.js.es6
+++ b/assets/javascripts/discourse/initializers/retort-init.js.es6
@@ -25,12 +25,12 @@ function initializePlugin(api) {
     Retort.storeWidget(helper)
 
     return _.map(post.retorts, (retort) => {
-      let usernames = retort.usernames;
+      { usernames, emoji } = retort;
       let contents = [];
 
       if (siteSettings.retort_standard_count && usernames.length > 0) {
         contents.push(helper.attach('retort-count', {
-          emoji: retort.emoji,
+          emoji,
           count: usernames.length
         }));
       }

--- a/assets/javascripts/discourse/initializers/retort-init.js.es6
+++ b/assets/javascripts/discourse/initializers/retort-init.js.es6
@@ -71,10 +71,14 @@ function initializePlugin(api) {
 
     retortName(retort) {
       let fragments = retort.split('_');
-      fragments.pop();
-      fragments.forEach(frag => {
-        frag = frag.charAt(0).toUpperCase() + frag.slice(1);
+
+      let namespaceIndex = fragments.indexOf('retort');
+      if (namespaceIndex !== -1) fragments.splice(namespaceIndex, 1);
+
+      fragments = fragments.map(frag => {
+        return frag.charAt(0).toUpperCase() + frag.slice(1);
       });
+
       return fragments.join(' ');
     },
 

--- a/assets/javascripts/discourse/initializers/retort-init.js.es6
+++ b/assets/javascripts/discourse/initializers/retort-init.js.es6
@@ -24,13 +24,11 @@ function initializePlugin(api) {
 
     Retort.storeWidget(helper);
 
-    const alternateCount = siteSettings.retort_alternate_count;
-
     return _.map(post.retorts, (retort) => {
       let usernames = retort.usernames;
       let contents = [];
 
-      if (alternateCount && usernames.length > 0) {
+      if (siteSettings.retort_standard_count && usernames.length > 0) {
         contents.push(helper.attach('retort-count', {
           emoji: retort.emoji,
           count: usernames.length
@@ -41,8 +39,7 @@ function initializePlugin(api) {
         helper.attach('retort-toggle', {
           post:           post,
           usernames:      usernames,
-          emoji:          retort.emoji,
-          alternateCount: alternateCount
+          emoji:          retort.emoji
         })
       )
 

--- a/assets/javascripts/discourse/widgets/retort-count.js.es6
+++ b/assets/javascripts/discourse/widgets/retort-count.js.es6
@@ -1,21 +1,16 @@
 import { createWidget } from 'discourse/widgets/widget'
-import Retort from '../lib/retort'
+import { h } from 'virtual-dom'
 
 export default createWidget('retort-toggle', {
-  tagName: 'span.post-retort-count',
-  buildKey: (attrs) => `retort-count-${attrs.emoji}-${attrs.usernames.length}`,
+  tagName: 'div.post-retort.post-retort-count',
+  buildKey: (attrs) => `retort-count-${attrs.emoji}-${attrs.count}`,
 
-  defaultState(attrs) {
-    return {
-      emoji:          attrs.emoji,
-      usernames:      attrs.usernames,
-      alternateCount: attrs.alternateCount
-    }
-  },
-
-  click() {
-    this.sendWidgetAction('showAvatarsFor', this.state.emoji);
-  },
-
-  html() { return template.render(this) }
+  html(attrs) {
+    return this.attach('button', {
+      action: 'toggleWhoRetorted',
+      actionParam: attrs.emoji,
+      contents: h('span', `${attrs.count}`),
+      classes: 'btn-flat'
+    });
+  }
 })

--- a/assets/javascripts/discourse/widgets/retort-count.js.es6
+++ b/assets/javascripts/discourse/widgets/retort-count.js.es6
@@ -1,0 +1,21 @@
+import { createWidget } from 'discourse/widgets/widget'
+import Retort from '../lib/retort'
+
+export default createWidget('retort-toggle', {
+  tagName: 'span.post-retort-count',
+  buildKey: (attrs) => `retort-count-${attrs.emoji}-${attrs.usernames.length}`,
+
+  defaultState(attrs) {
+    return {
+      emoji:          attrs.emoji,
+      usernames:      attrs.usernames,
+      alternateCount: attrs.alternateCount
+    }
+  },
+
+  click() {
+    this.sendWidgetAction('showAvatarsFor', this.state.emoji);
+  },
+
+  html() { return template.render(this) }
+})

--- a/assets/javascripts/discourse/widgets/retort-toggle.js.es6
+++ b/assets/javascripts/discourse/widgets/retort-toggle.js.es6
@@ -11,7 +11,8 @@ export default createWidget('retort-toggle', {
     return {
       emoji:     attrs.emoji,
       post:      attrs.post,
-      usernames: attrs.usernames
+      usernames: attrs.usernames,
+      alternateCount: attrs.alternateCount
     }
   },
 

--- a/assets/javascripts/discourse/widgets/retort-toggle.js.es6
+++ b/assets/javascripts/discourse/widgets/retort-toggle.js.es6
@@ -16,7 +16,9 @@ export default createWidget('retort-toggle', {
   },
 
   click() {
-    Retort.updateRetort(this.state.post.id, this.state.emoji)
+    const { emoji, post, usernames } = this.state;
+    this.sendWidgetAction('toggledRetort', emoji);
+    Retort.updateRetort(post.id, emoji)
   },
 
   html() { return template.render(this) }

--- a/assets/javascripts/discourse/widgets/retort-toggle.js.es6
+++ b/assets/javascripts/discourse/widgets/retort-toggle.js.es6
@@ -11,8 +11,7 @@ export default createWidget('retort-toggle', {
     return {
       emoji:     attrs.emoji,
       post:      attrs.post,
-      usernames: attrs.usernames,
-      alternateCount: attrs.alternateCount
+      usernames: attrs.usernames
     }
   },
 

--- a/assets/javascripts/discourse/widgets/templates/retort-toggle.js.es6
+++ b/assets/javascripts/discourse/widgets/templates/retort-toggle.js.es6
@@ -5,7 +5,6 @@ export default Ember.Object.create({
   render(widget) {
     this.state = widget.state
     let template = [this.emoji()];
-    console.log(this.state);
     if (!this.state.alternateCount) {
       template.push(this.count(), this.tooltip());
     }

--- a/assets/javascripts/discourse/widgets/templates/retort-toggle.js.es6
+++ b/assets/javascripts/discourse/widgets/templates/retort-toggle.js.es6
@@ -4,11 +4,7 @@ import { emojiUrlFor } from 'discourse/lib/text'
 export default Ember.Object.create({
   render(widget) {
     this.state = widget.state
-    let template = [this.emoji()];
-    if (!Discourse.SiteSettings.retort_standard_count) {
-      template.push(this.count(), this.tooltip());
-    }
-    return template;
+    return [this.emoji(), this.count(), this.tooltip()];
   },
 
   emoji() {
@@ -16,11 +12,12 @@ export default Ember.Object.create({
   },
 
   count() {
-    if (this.state.usernames.length < 2) { return }
+    if (this.state.usernames.length < 2 || Discourse.SiteSettings.retort_standard_count) { return }
     return h('span.post-retort__count', this.state.usernames.length.toString())
   },
 
   tooltip() {
+    if (Discourse.SiteSettings.retort_standard_count) { return }
     return h('span.post-retort__tooltip', this.sentence())
   },
 

--- a/assets/javascripts/discourse/widgets/templates/retort-toggle.js.es6
+++ b/assets/javascripts/discourse/widgets/templates/retort-toggle.js.es6
@@ -4,7 +4,12 @@ import { emojiUrlFor } from 'discourse/lib/text'
 export default Ember.Object.create({
   render(widget) {
     this.state = widget.state
-    return [this.emoji(), this.count(), this.tooltip()]
+    let template = [this.emoji()];
+    console.log(this.state);
+    if (!this.state.alternateCount) {
+      template.push(this.count(), this.tooltip());
+    }
+    return template;
   },
 
   emoji() {

--- a/assets/javascripts/discourse/widgets/templates/retort-toggle.js.es6
+++ b/assets/javascripts/discourse/widgets/templates/retort-toggle.js.es6
@@ -5,7 +5,7 @@ export default Ember.Object.create({
   render(widget) {
     this.state = widget.state
     let template = [this.emoji()];
-    if (!this.state.alternateCount) {
+    if (!Discourse.SiteSettings.retort_standard_count) {
       template.push(this.count(), this.tooltip());
     }
     return template;

--- a/assets/stylesheets/retort.scss
+++ b/assets/stylesheets/retort.scss
@@ -91,3 +91,19 @@
     .emoji-picker { bottom: auto !important; }
   }
 }
+
+.post-retort-count {
+  padding: 0;
+  margin: 20px 0 20px 5px;
+
+  button.btn {
+    background: none;
+    padding: 6px;
+    min-height: initial;
+
+    &:hover {
+      background: none;
+      color: $primary;
+    }
+  }
+}

--- a/assets/stylesheets/retort.scss
+++ b/assets/stylesheets/retort.scss
@@ -92,9 +92,10 @@
   }
 }
 
-.post-retort-count {
+div.post-retort-count {
   padding: 0;
   margin: 20px 0 20px 5px;
+  background: transparent;
 
   button.btn {
     background: none;
@@ -106,4 +107,8 @@
       color: $primary;
     }
   }
+}
+
+.who-retorted a:last-of-type {
+  margin-right: 7px;
 }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2,3 +2,8 @@ en:
   js:
     retort:
       title: 'add an emoji reaction to this post'
+
+    post:
+      actions:
+        people:
+          retort: reacted with {{count}}

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -10,4 +10,4 @@ en:
     retort_tl2_max_per_day_multiplier: "Increase limit of retorts per day for tl2 (member) by multiplying with this number"
     retort_tl3_max_per_day_multiplier: "Increase limit of retorts per day for tl3 (regular) by multiplying with this number"
     retort_tl4_max_per_day_multiplier: "Increase limit of retorts per day for tl4 (leader) by multiplying with this number"
-    retort_standard_count: "Use standard Discourse style for displaying retort count."
+    retort_standard_count: "Show a clickable count next to retorts, and display a list of users who retorted at the bottom of the post when count is clicked."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -10,4 +10,4 @@ en:
     retort_tl2_max_per_day_multiplier: "Increase limit of retorts per day for tl2 (member) by multiplying with this number"
     retort_tl3_max_per_day_multiplier: "Increase limit of retorts per day for tl3 (regular) by multiplying with this number"
     retort_tl4_max_per_day_multiplier: "Increase limit of retorts per day for tl4 (leader) by multiplying with this number"
-    retort_alternate_count: "Use alternate display for retort count."
+    retort_standard_count: "Use standard Discourse style for displaying retort count."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -10,3 +10,4 @@ en:
     retort_tl2_max_per_day_multiplier: "Increase limit of retorts per day for tl2 (member) by multiplying with this number"
     retort_tl3_max_per_day_multiplier: "Increase limit of retorts per day for tl3 (regular) by multiplying with this number"
     retort_tl4_max_per_day_multiplier: "Increase limit of retorts per day for tl4 (leader) by multiplying with this number"
+    retort_alternate_count: "Use alternate display for retort count."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -17,3 +17,4 @@ plugins:
   retort_tl2_max_per_day_multiplier: 1.5
   retort_tl3_max_per_day_multiplier: 2
   retort_tl4_max_per_day_multiplier: 3
+  retort_alternate_count: false

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -17,6 +17,6 @@ plugins:
   retort_tl2_max_per_day_multiplier: 1.5
   retort_tl3_max_per_day_multiplier: 2
   retort_tl4_max_per_day_multiplier: 3
-  retort_alternate_count:
+  retort_standard_count:
     default: false
     client: true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -17,4 +17,6 @@ plugins:
   retort_tl2_max_per_day_multiplier: 1.5
   retort_tl3_max_per_day_multiplier: 2
   retort_tl4_max_per_day_multiplier: 3
-  retort_alternate_count: false
+  retort_alternate_count:
+    default: false
+    client: true

--- a/plugin.rb
+++ b/plugin.rb
@@ -20,7 +20,7 @@ after_initialize do
 
   ::Retort::Engine.routes.draw do
     post   "/:post_id"       => "retorts#update"
-    get    "/:post_id/users" => "retort#users"
+    get    "/:post_id/users" => "retorts#users"
   end
 
   Discourse::Application.routes.append do
@@ -36,7 +36,7 @@ after_initialize do
     end
 
     def users
-      render_json_dump(ActiveModel::ArraySerializer.new(User.find_by(username: retort.value), each_serializer: BasicUserSerializer))
+      render_json_dump(ActiveModel::ArraySerializer.new(User.where(username: retort.value), each_serializer: BasicUserSerializer))
     end
 
     private

--- a/plugin.rb
+++ b/plugin.rb
@@ -19,7 +19,8 @@ after_initialize do
   end
 
   ::Retort::Engine.routes.draw do
-    post   "/:post_id" => "retorts#update"
+    post   "/:post_id"       => "retorts#update"
+    get    "/:post_id/users" => "retort#users"
   end
 
   Discourse::Application.routes.append do
@@ -32,6 +33,10 @@ after_initialize do
     def update
       retort.toggle_user(current_user)
       respond_with_retort
+    end
+
+    def users
+      render_json_dump(ActiveModel::ArraySerializer.new(User.find_by(username: retort.value), each_serializer: BasicUserSerializer))
     end
 
     private


### PR DESCRIPTION
@gdpelican This converts the retort count style to the Discourse standard, i.e. the same as the like count, showing a list of users who have retorted with the specific retort below the post.

The change is toggled with a site setting "retort standard count", partly for the purposes of comparison in testing. This could be removed if you wanted to go this way entirely with retort counts.

<img width="368" alt="screenshot at dec 04 12-03-01" src="https://user-images.githubusercontent.com/5931623/49411366-b78a3300-f7bc-11e8-8d11-1b646647f614.png">

