### PR TITLE
Handle case when post hasn't loaded

### DIFF
--- a/assets/javascripts/discourse/lib/retort.js.es6
+++ b/assets/javascripts/discourse/lib/retort.js.es6
@@ -28,7 +28,7 @@ export default Ember.Object.create({
 
   disabledFor(postId) {
     let post = this.postFor(postId)
-    let categoryName = post.get('topic.category.name') || ''
+    let categoryName = post ? (post.get('topic.category.name') || '') : ''
     return _.contains(disabledCategories, categoryName.toLowerCase()) || post.get('topic.archived')
   },
 


### PR DESCRIPTION
I'm seeing this exception on a few different sites.

```
Uncaught TypeError: Cannot read property 'get' of undefined
    at i.disabledFor (_plugin-third-party-0115afc561846db1fe45130d63292b42fa5778a39edd0491c15a17035dd1f99b.js:956)
    at _plugin-third-party-0115afc561846db1fe45130d63292b42fa5778a39edd0491c15a17035dd1f99b.js:877
    at _application-3731fb7468a9fdd18bd1f9aa382b6c9d370f026823b4163e5ac39d73a63fcd05.js:70799
    at Array.map (<anonymous>)
    at c (_application-3731fb7468a9fdd18bd1f9aa382b6c9d370f026823b4163e5ac39d73a63fcd05.js:70798)
    at t.html (_application-3731fb7468a9fdd18bd1f9aa382b6c9d370f026823b4163e5ac39d73a63fcd05.js:67772)
    at t.m [as draw] (_application-3731fb7468a9fdd18bd1f9aa382b6c9d370f026823b4163e5ac39d73a63fcd05.js:70875)
    at t.value (_application-3731fb7468a9fdd18bd1f9aa382b6c9d370f026823b4163e5ac39d73a63fcd05.js:71052)
    at i (_vendor-d5c90f757e42fa5fccea3a56939f620e399820415c6cd21858590e0fc017e5ff.js:15901)
    at r (_vendor-d5c90f757e42fa5fccea3a56939f620e399820415c6cd21858590e0fc017e5ff.js:15884)
```