### PR TITLE
Enclose all retorts within a div

### DIFF
--- a/assets/javascripts/discourse/initializers/retort-init.js.es6
+++ b/assets/javascripts/discourse/initializers/retort-init.js.es6
@@ -20,13 +20,13 @@ function initializePlugin(api) {
 
     Retort.storeWidget(helper)
 
-    return _.map(post.retorts, (retort) => {
+    return helper.h('div.post-retort-area.clearfix', _.map(post.retorts, (retort) => {
       return helper.attach('retort-toggle', {
         post:      post,
         usernames: retort.usernames,
         emoji:     retort.emoji
       })
-    })
+    }))
   })
 
   if (!Discourse.User.current() || !siteSettings.retort_enabled) { return }


### PR DESCRIPTION
This will help users that want to place the retorts on a separate row above the post actions. This is especially helpful if your post has at least a handful of retorts. It’s also very handy when using a mobile device, where a single retort makes the full action bar not fit within the screen.