### PR TITLE
fix: remove the z-index on post

### DIFF
--- a/assets/stylesheets/retort.scss
+++ b/assets/stylesheets/retort.scss
@@ -1,4 +1,4 @@
-.topic-post .topic-body { z-index: 3; }
+// .topic-post .topic-body { z-index: 3; }
 
 .post-retort {
   background: dark-light-diff($primary, $secondary, 25%, -25%);


### PR DESCRIPTION
With material design theme, the user card causes the flair of the group to go behind the card instead of in front of.

**Before**
![](https://w.wew.wtf/yequsu.png)

**After**
![](https://w.wew.wtf/wnaiih.png)

Not sure why this only recently started showing, in the past it has been fine. Since an update to beta3 it caused this, but this seems to be the only thing causing it to do this, nothing else is being effected by this `z-index` either so it's fine.

Thanks to @TheIndra55 for actually identifying the source of the issue.