### PR TITLE
Temporary fix: handle various discourse changes

### DIFF
--- a/assets/javascripts/discourse/lib/retort.js.es6
+++ b/assets/javascripts/discourse/lib/retort.js.es6
@@ -50,7 +50,7 @@ export default Ember.Object.create({
   },
 
   openPicker(post) {
-    this.set('picker.active', true)
+    this.set('picker.isActive', true)
     this.set('picker.post', post)
   },
 
@@ -58,7 +58,7 @@ export default Ember.Object.create({
     this.set('picker', picker)
     this.set('picker.emojiSelected', retort => (
       this.updateRetort(picker.post, retort)).then(() => (
-        picker.set('active', false)
+        picker.set('isActive', false)
       ))
     )
   }

--- a/assets/javascripts/discourse/templates/connectors/above-site-header/emoji-picker-wrapper.hbs
+++ b/assets/javascripts/discourse/templates/connectors/above-site-header/emoji-picker-wrapper.hbs
@@ -1,7 +1,7 @@
 {{
   emoji-picker
   retort=true
-  active=active
+  isActive=isActive
   emojiSelected=emojiSelected
   automaticPositioning=false
 }}

--- a/assets/stylesheets/retort.scss
+++ b/assets/stylesheets/retort.scss
@@ -78,14 +78,17 @@
       flex-wrap: wrap;
       justify-content: center;
       border: 0;
-
-      button.emoji {
+      margin-top: 80px;
+      
+      .limited-emoji-set {
+        display: flex;
+      }
+      
+      img.emoji {
         display: block;
-        width: 40px;
-        height: 40px;
-        background-size: 40px;
-        margin: 0;
-        padding: 10px 0;
+        margin: 0 10px 0 0;
+        padding: 0;
+        cursor: pointer;
       }
     }
 


### PR DESCRIPTION
Retort was broken by various Discourse globals being changed, and then a large refactor of the emoji-picker: https://github.com/discourse/discourse/commit/226be994dab13e6358ed977877d2c27788dc73af#diff-1973e9435c64d306dcfe18282e65f6f5. This is a temporary fix that (just) makes it work with the new picker. Will definitely need more work.