### PR TITLE
Properly support the new emoji picker

### DIFF
--- a/assets/javascripts/discourse/initializers/retort-init.js.es6
+++ b/assets/javascripts/discourse/initializers/retort-init.js.es6
@@ -1,7 +1,7 @@
 import { withPluginApi } from 'discourse/lib/plugin-api'
 import { emojiUrlFor } from 'discourse/lib/text'
 import { schedule } from '@ember/runloop'
-import computed from 'discourse-common/utils/decorators'
+import { default as computed, observes } from 'discourse-common/utils/decorators'
 import { action } from "@ember/object";
 import TopicRoute from 'discourse/routes/topic'
 import Retort from '../lib/retort'
@@ -75,9 +75,9 @@ function initializePlugin(api) {
     activeRetort() {
       return this.retort && this.isActive
     },
-
-    @action
-    onShow() {
+    
+    @observes('isActive')
+    _setupLimited() {
       if (this.limited) {
         const emojis = retort_allowed_emojis.split('|')
         const basis = (100 / this._emojisPerRow[emojis.length] || 5)
@@ -103,8 +103,6 @@ function initializePlugin(api) {
           });
         });
       }
-      
-      this._super();
     },
 
     _emojisPerRow: {

--- a/assets/javascripts/discourse/initializers/retort-init.js.es6
+++ b/assets/javascripts/discourse/initializers/retort-init.js.es6
@@ -1,8 +1,10 @@
 import { withPluginApi } from 'discourse/lib/plugin-api'
 import { emojiUrlFor } from 'discourse/lib/text'
-import { schedule } from '@ember/runloop'
+import { schedule, later } from '@ember/runloop'
 import { default as computed, observes } from 'discourse-common/utils/decorators'
 import { action } from "@ember/object";
+import { createPopper } from "@popperjs/core";
+import { safariHacksDisabled } from "discourse/lib/utilities";
 import TopicRoute from 'discourse/routes/topic'
 import Retort from '../lib/retort'
 import User from 'discourse/models/user'
@@ -44,7 +46,8 @@ function initializePlugin(api) {
       action: 'clickRetort',
       icon: 'far-smile',
       title: 'retort.title',
-      position: 'first'
+      position: 'first',
+      className: 'retort'
     }
   })
 
@@ -53,19 +56,7 @@ function initializePlugin(api) {
   })
 
   api.modifyClass('component:emoji-picker', {
-    classNameBindings: [
-      'retort:emoji-picker--retort',
-      'limited:emoji-picker--retort-limited',
-      'activeRetort:emoji-picker--retort-active'
-    ],
     
-    didReceiveAttrs() {
-      this._super(...arguments);
-      if (this.retort) {
-        this.set('tagName', 'div');
-      }
-    },
-
     @computed('retort')
     limited() {
       return this.retort && retort_limited_emoji_set
@@ -76,33 +67,104 @@ function initializePlugin(api) {
       return this.retort && this.isActive
     },
     
-    @observes('isActive')
-    _setupLimited() {
-      if (this.limited) {
-        const emojis = retort_allowed_emojis.split('|')
-        const basis = (100 / this._emojisPerRow[emojis.length] || 5)
+    @observes("isActive")
+    _setup() {
+      if (this.retort) {
+        this._setupRetort();
+      } else {
+        this._super();
+      }
+    },
+    
+    _setupRetort() {
+      if (this.isActive) {
+        this.onShowRetort();
+      } else {
+        this.onClose();
+      }
+    },
+    
+    // See onShow in emoj-picker for logic pattern
+    @action
+    onShowRetort() {
+      if (!this.limited) {
+        this.set("isLoading", true);
+      }
+    
+      schedule("afterRender", () => {
+        document.addEventListener("click", this.handleOutsideClick);
+        
+        const post = this.post;
+        const emojiPicker = document.querySelector(".emoji-picker");
+        const retortButton = document.querySelector(`
+          article[data-post-id="${post.id}"] .post-controls .retort`
+        );
+                
+        if (!emojiPicker || !retortButton) return false;
 
-        schedule('afterRender', this, () => {
-          $('.emoji-picker').html(`
+        if (!this.site.isMobileDevice) {
+          this._popper = createPopper(
+            retortButton,
+            emojiPicker,
+            {
+              placement: this.limited ? "top" : "auto"
+            }
+          );
+        }
+        
+        if (this.limited) {
+          const emojis = retort_allowed_emojis.split('|')
+          const basis = (100 / this._emojisPerRow[emojis.length] || 5)
+
+          emojiPicker.innerHTML = `
             <div class='limited-emoji-set'>
               ${emojis.map(code => `<img
                 src="${emojiUrlFor(code)}"
-                width=20
-                height=20
+                width=40
+                height=40
                 title='${code}'
                 class='emoji' />`).join('')}
             </div>
-          `)
-          $('.emoji-picker--retort').on('click', (e) => {
-            if ($(e.target).hasClass('emoji')) {
+          `;
+          
+          emojiPicker.classList.add("has-limited-set");
+          
+          emojiPicker.onclick = (e) => {
+            if (e.target.classList.contains("emoji")) {
               this.onEmojiSelection(e);
             } else {
               this.set('isActive', false);
               this.onClose();
             }
-          });
-        });
-      }
+          };
+        } else {
+          emojiPicker
+            .querySelectorAll(".emojis-container .section .section-header")
+            .forEach(p => this._sectionObserver.observe(p));
+
+          later(() => {
+            this.set("isLoading", false);
+            this.applyDiscourseTrick(emojiPicker);
+          }, 50);
+        }      
+      });
+    },
+    
+    // Lifted from onShow in emoji-picker. See note in that function concerning its utility.
+    applyDiscourseTrick(emojiPicker) {
+      schedule("afterRender", () => {
+        if (
+          (!this.site.isMobileDevice || this.isEditorFocused) &&
+          !safariHacksDisabled()
+        ) {
+          const filter = emojiPicker.querySelector("input.filter");
+          filter && filter.focus();
+        }
+
+        if (this.selectedDiversity !== 0) {
+          this._applyDiversity(this.selectedDiversity);
+        }
+      });
     },
 
     _emojisPerRow: {

--- a/assets/javascripts/discourse/templates/connectors/above-site-header/emoji-picker-wrapper.hbs
+++ b/assets/javascripts/discourse/templates/connectors/above-site-header/emoji-picker-wrapper.hbs
@@ -2,6 +2,7 @@
   emoji-picker
   retort=true
   isActive=isActive
+  post=post
   emojiSelected=emojiSelected
-  automaticPositioning=false
+  onEmojiPickerClose=(action (mut isActive) false)
 }}

--- a/assets/stylesheets/retort.scss
+++ b/assets/stylesheets/retort.scss
@@ -53,47 +53,28 @@
   }
 }
 
-.emoji-picker--retort {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-
-  &-active {
-    position: fixed;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    z-index: 10000;
-
-    .emoji-picker {
-      bottom: auto !important;
+.emoji-picker.has-limited-set {
+  height: auto;
+  width: auto;
+  padding: 10px;
+  
+  .limited-emoji-set {
+    display: flex;
+  }
+  
+  img.emoji {
+    margin-right: 10px;
+    cursor: pointer;
+    
+    &:last-of-type {
+      margin-right: 0;
     }
   }
+}
 
-  &-limited {
-    .emoji-picker {
-      width: auto !important;
-      height: auto !important;
-      flex-wrap: wrap;
-      justify-content: center;
-      border: 0;
-      margin-top: 80px;
-      
-      .limited-emoji-set {
-        display: flex;
-      }
-      
-      img.emoji {
-        display: block;
-        margin: 0 10px 0 0;
-        padding: 0;
-        cursor: pointer;
-      }
-    }
-
-    .categories-column {
-      display: none;
-    }
-  }
+.mobile-view .emoji-picker.has-limited-set {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%);
 }


### PR DESCRIPTION
The emoji picker has been refactored. This adopts the approach of the new picker. Specifically:
- Use of popper.js for positioning
- Removal of jQuery
- Ember run loop usage