### PR TITLE
Remove lodash from plugin

### DIFF
--- a/assets/javascripts/discourse/initializers/retort-init.js.es6
+++ b/assets/javascripts/discourse/initializers/retort-init.js.es6
@@ -25,9 +25,7 @@ function initializePlugin(api) {
 
     Retort.storeWidget(helper)
 
-    return _.map(post.retorts, ({ usernames, emoji }) => {
-      return helper.attach('retort-toggle', { post, usernames, emoji })
-    })
+    return post.retorts.map(({usernames, emoji}) => helper.attach('retort-toggle', { post, usernames, emoji }))
   })
 
   if (!User.current() || !retort_enabled) { return }

--- a/assets/javascripts/discourse/initializers/retort-init.js.es6
+++ b/assets/javascripts/discourse/initializers/retort-init.js.es6
@@ -25,7 +25,9 @@ function initializePlugin(api) {
 
     Retort.storeWidget(helper)
 
-    return post.retorts.map(({usernames, emoji}) => helper.attach('retort-toggle', { post, usernames, emoji }))
+    return post.retorts.map(({usernames, emoji}) => {
+      return helper.attach('retort-toggle', { post, usernames, emoji });
+    });
   })
 
   if (!User.current() || !retort_enabled) { return }

--- a/assets/javascripts/discourse/lib/retort.js.es6
+++ b/assets/javascripts/discourse/lib/retort.js.es6
@@ -46,8 +46,7 @@ export default Ember.Object.create({
     if (!post.topic.details.can_create_post) { return true }
 
     const disabledCategories = this.disabledCategories();
-
-    let categoryName = post.get('topic.category.name').toString().toLowerCase()
+    let categoryName = post.get('topic.category.name').toString().toLowerCase();
 
     return disabledCategories.includes(categoryName) || post.get('topic.archived')
   },

--- a/assets/javascripts/discourse/lib/retort.js.es6
+++ b/assets/javascripts/discourse/lib/retort.js.es6
@@ -34,18 +34,21 @@ export default Ember.Object.create({
       data: { retort }
     }).catch(popupAjaxError)
   },
-  
+
   disabledCategories() {
-    return _.compact(_.invoke(Discourse.SiteSettings.retort_disabled_categories.split('|'), 'toLowerCase'));
+    const categories = Discourse.SiteSettings.retort_disabled_categories.split('|');
+    return categories.map(cat => cat.toLowerCase()).filter(Boolean)
   },
 
   disabledFor(postId) {
     const post = this.postFor(postId)
     if (!post) { return true }
     if (!post.topic.details.can_create_post) { return true }
-    
+
     const disabledCategories = this.disabledCategories();
-    let categoryName = _.toString(post.get('topic.category.name')).toLowerCase()
+
+    let categoryName = post.get('topic.category.name').toString().toLowerCase()
+
     return disabledCategories.includes(categoryName) || post.get('topic.archived')
   },
 


### PR DESCRIPTION
lodash is being deprecated in Discourse:

https://github.com/discourse/discourse/commit/8c0f18794ef57ddf944bbabcb9bdea5da4b32c75

I believe this commit removes it from the retort plugin.