### PR TITLE
Enforce Limited Emoji Set Backend

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -30,8 +30,12 @@ after_initialize do
     before_action :verify_post_and_user, only: :update
 
     def update
-      retort.toggle_user(current_user)
-      respond_with_retort
+      if SiteSetting.retort_limited_emoji_set && !SiteSetting.retort_allowed_emojis.split("|").include?(params[:retort])
+        respond_with_unprocessable("Requested retort is disabled")
+      else
+        retort.toggle_user(current_user)
+        respond_with_retort
+      end
     end
 
     private


### PR DESCRIPTION
As of now, setting a limited emoji set just means users only see specific emojis to react with. This means that they can still send requests for any emoji (that return successful), even if it is not on the limited list.