### PR TITLE
Fix the background color & border to adapt well to dark themes

### DIFF
--- a/assets/stylesheets/retort.scss
+++ b/assets/stylesheets/retort.scss
@@ -7,6 +7,8 @@
   margin: 20px 2px;
   position: relative;
   outline: 0;
+  background-color: transparent;
+  border-color: transparent;
 
   &:hover .post-retort__tooltip { opacity: 1 }
 


### PR DESCRIPTION
This fix is simple, but enables much better readability with any theme that isn't pure white or where the user does not necessarily have access to the theme's colors to adapt it.

Essentially making the background & border transparent.